### PR TITLE
Add optional theme path

### DIFF
--- a/eyeglass-exports.js
+++ b/eyeglass-exports.js
@@ -1,13 +1,11 @@
 "use strict";
 
-var theme_path = process.env.PWD;
 var path = require('path');
 var fs   = require('fs');
 var glob = require('glob');
 var yaml = require('js-yaml');
-var dir = fs.readdirSync(theme_path);
-var breakpointsFile = glob.sync('*.breakpoints.yml', {'cwd': theme_path});
-var breakpoints = yaml.safeLoad(fs.readFileSync(breakpointsFile[0], 'utf8'));
+var breakpointsFile;
+var breakpoints = [];
 
 /**
  * Custom Function to get the value of a media query
@@ -48,11 +46,21 @@ var getMediaQuery = function(targetLabel, targetGroup) {
 }
 
 module.exports = function(eyeglass, sass) {
+  var dsbOptions = eyeglass.options.drupalSassBreakpoints || process.env.PWD;
+  var themePath = dsbOptions.themePath || process.env.PWD;
+  breakpointsFile = glob.sync('*.breakpoints.yml', {'cwd': themePath});
+
+  if (breakpointsFile.length) {
+    breakpoints = yaml.safeLoad(fs.readFileSync(themePath + breakpointsFile[0], 'utf8'));
+  }
+  else {
+    console.log('No breakoints file found. You may need to add \ndrupalSassBreakpoints: {\n\tthemePath: \'/path/to/theme\'\n}\nto your the SASS options passed to Eyeglass.');
+  }
+
   return {
     sassDir: path.join(__dirname, 'sass'),
     functions: {
       "dsb($label, $group: '')": function(label, group, done) {
-
         var label = label.getValue();
         var group = group.getValue();
 

--- a/eyeglass-exports.js
+++ b/eyeglass-exports.js
@@ -54,7 +54,7 @@ module.exports = function(eyeglass, sass) {
     breakpoints = yaml.safeLoad(fs.readFileSync(themePath + breakpointsFile[0], 'utf8'));
   }
   else {
-    console.log('No breakoints file found. You may need to add \ndrupalSassBreakpoints: {\n\tthemePath: \'/path/to/theme\'\n}\nto your the SASS options passed to Eyeglass.');
+    console.log('No breakpoints file found. You may need to add \ndrupalSassBreakpoints: {\n\tthemePath: \'/path/to/theme\'\n}\nto your the SASS options passed to Eyeglass.');
   }
 
   return {


### PR DESCRIPTION
The eyeglass module portion of this code assumes that `process.env.PWD` is the theme directory.

This change allows one to add 

```
drupalSassBreakpoints: {
  themePath: '/path/to/theme/'
}
```

to their eyeglass options to specify a path to the theme.
## Test
- Move your `*.breakpoint.yml` file somewhere else.
- Compile and see an error about needing to specificy a theme path.
- Add the above options to your eyeglass call (Probably in your grunt/gulp file styles task) with the path to your breakpoint file.
  - This is added in the same way that other options are added. Psuedocode example from a gulpfile:

```
var sassOptions = {
    outputStyle: 'expanded',
    eyeglass: {
      enableImportOnce: false
    },
    drupalSassBreakpoints: {
      themePath: themeDir+'/'
    }
  };
// Your style task here...
.pipe(sass(eyeglass(config.sassOptions)).on('error', sass.logError))
// style task continued...
```
- Compile and make sure your mq is working.
